### PR TITLE
[LangchainChatAgent] Make the `llm` a property and control how `message_history` is updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 bin/
 lib/
 share/

--- a/src/hermetic/agents/langchain_chat_agent.py
+++ b/src/hermetic/agents/langchain_chat_agent.py
@@ -71,8 +71,14 @@ class LangchainChatAgent(Agent):
     def greet(self):
         return None
 
+    def create_human_message_for_input(self, input):
+        """When a human input is passed in to process_input, it turns it to a langchain HumanMessag with this method.
+
+        Subclasses can override to add any custom logic to preprocess the input; e.g., recognizing commands."""
+        return HumanMessage(content=input)
+
     def process_input(self, input):
-        self.update_message_history(HumanMessage(content=input))
+        self.update_message_history(self.create_human_message_for_inpu(input))
         myq = Queue()
         thread = Thread(target = self.llm.predict_messages, kwargs =
                         {
@@ -93,7 +99,6 @@ class LangchainChatAgent(Agent):
 
     def update_message_history(self, msg: Union[AIMessage, HumanMessage, SystemMessage]):
         """The only correct way to update the message history, allowing subclasses to override and include custom logic.
-
 
         The message history should not be accessed directly, but only through the property or this method. Otherwise,
         any custom logic that the subclasses assume will be applied to each newly added message may not be applied.

--- a/src/hermetic/agents/langchain_chat_agent.py
+++ b/src/hermetic/agents/langchain_chat_agent.py
@@ -43,9 +43,11 @@ class LangchainChatAgent(Agent):
         def __int__(
                 self,
                 agent: "LangchainChatAgent",
-                messages: Optional[List[Union[AIMessage, HumanMessage, SystemMessage]]] = None):
+                messages: Optional[List[Union[AIMessage, HumanMessage, SystemMessage]]] = []):
             self._agent = agent
-            self._messages: List[Union[AIMessage, HumanMessage, SystemMessage]] = messages[:] if messages else []
+            self._messages: List[Union[AIMessage, HumanMessage, SystemMessage]] = []
+            for msg in messages:
+                self.append(msg)  # So that the `on_message_history_append` callback is called.
 
         @property
         def messages(self):
@@ -54,7 +56,6 @@ class LangchainChatAgent(Agent):
         def append(self, msg: Union[AIMessage, HumanMessage, SystemMessage]) -> None:
             self._messages.append(msg)
             self._agent.on_message_history_append()
-
 
     def __init__(self, environment, id: str = None):
         super().__init__(environment, id)

--- a/src/hermetic/agents/langchain_chat_agent.py
+++ b/src/hermetic/agents/langchain_chat_agent.py
@@ -43,9 +43,11 @@ class LangchainChatAgent(Agent):
         def __int__(
                 self,
                 agent: "LangchainChatAgent",
-                messages: Optional[List[Union[AIMessage, HumanMessage, SystemMessage]]] = None):
+                messages: Optional[List[Union[AIMessage, HumanMessage, SystemMessage]]] = []):
             self._agent = agent
-            self._messages: List[Union[AIMessage, HumanMessage, SystemMessage]] = messages[:] if messages else []
+            self._messages: List[Union[AIMessage, HumanMessage, SystemMessage]] = []
+            for msg in messages:
+                self.append(msg)  # So that the `on_message_history_append` callback is called.
 
         @property
         def messages(self):
@@ -53,8 +55,7 @@ class LangchainChatAgent(Agent):
 
         def append(self, msg: Union[AIMessage, HumanMessage, SystemMessage]) -> None:
             self._messages.append(msg)
-            self._agent.on_message_history_append()
-
+            self._agent.on_message_history_append(msg)
 
     def __init__(self, environment, id: str = None):
         super().__init__(environment, id)
@@ -112,8 +113,11 @@ class LangchainChatAgent(Agent):
         """
         self.message_history.append(HumanMessage(content=inp))
 
-    def on_message_history_append(self):
-        """Subclasses can override to update their state whenever a new message is appended to the `message_history`."""
+    def on_message_history_append(self, msg: Union[AIMessage, HumanMessage, SystemMessage]):
+        """Subclasses can override to update their state whenever a new message is appended to the `message_history`.
+
+        :param msg: The message that was appended to the message_history. Should be the same instance as message[-1].
+        """
         pass
 
     def create_predict_messages_callbacks(self) -> List:

--- a/src/hermetic/agents/langchain_chat_agent.py
+++ b/src/hermetic/agents/langchain_chat_agent.py
@@ -39,15 +39,23 @@ class LangchainChatAgent(Agent):
         def on_llm_end(self, response, *, run_id, parent_run_id, **kwargs):
             self.q.put(InputMarker.END)
 
-    def set_llm(self, llm):
-        self.llm = llm
+    @property
+    def llm(self):
+        """Return the LLM to be used for a prediction upon calling process_input.
 
+        Subclasses can override to choose a suitable LLM, for example based on the message_history."""
+        return self._llm
+
+    @llm.setter
+    def llm(self, llm):
+        """If you don't override the `llm` property, make sure to assign an LLM to it before calling `process_input`."""
+        self._llm = llm
 
     def __init__(self, environment, id: str = None):
         super().__init__(environment, id)
         self.message_history = []
         self.session_tag = f'session_{uuid.uuid4()}'
-
+        self._llm = None
 
     def greet(self):
         return None


### PR DESCRIPTION
As discussed in https://github.com/waleedkadous/ansari/issues/5:
- This allows the subclass to control which LLM, possibly of many, to use for a particular prediction.
- Also allows the subclass to update its state based on each additional message appended to the history